### PR TITLE
refractor css add career content

### DIFF
--- a/portfolio/src/main/webapp/career.html
+++ b/portfolio/src/main/webapp/career.html
@@ -6,17 +6,50 @@
         <link rel="stylesheet" href="style.css">
     </head>
     <body>
-    <div class="navBar">
-        <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="career.html" class="active">Career</a></li>
-            <li><a href="research.html">Research</a></li>
-            <li><a href="fun.html">Fun</a></li>
+        <ul class="navBar">
+            <li class="navBar"><a href="index.html">Home</a></li>
+            <li class="navBar"><a href="career.html" class="active">Career</a></li>
+            <li class="navBar"><a href="research.html">Research</a></li>
+            <li class="navBar"><a href="fun.html">Fun</a></li>
         </ul>
-    </div>
       <div id="content">
-        <h2>Career Goals</h2>
-        <p> Test </p>
+        <h1>Career Goals</h1>
+        <p> Get Money + Get Paid</p>
+        <h1>Experience</h1>
+        <ul class="experience">
+            <li><h2>STEP Intern @ Google</h2></li>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+                sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
+                ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit
+                in voluptate velit esse cillum dolore eu fugiat nulla pariatur. 
+                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+                deserunt mollit anim id est laborum. </p>            
+            <li><h2>Deep Learnign Engineer @ CACI</h2></li>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+                sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
+                ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit
+                in voluptate velit esse cillum dolore eu fugiat nulla pariatur. 
+                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+                deserunt mollit anim id est laborum. </p>
+            <li><h2>Computer Science Summer Institute @ Google</h2></li>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+                sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
+                ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit
+                in voluptate velit esse cillum dolore eu fugiat nulla pariatur. 
+                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+                deserunt mollit anim id est laborum. </p>
+            <li><h2>Junior Research Scientist @ CACI</h2></li>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+                sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
+                ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit
+                in voluptate velit esse cillum dolore eu fugiat nulla pariatur. 
+                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+                deserunt mollit anim id est laborum. </p>
+        </ul>
       </div>
     </body>
 </html>

--- a/portfolio/src/main/webapp/fun.html
+++ b/portfolio/src/main/webapp/fun.html
@@ -7,14 +7,12 @@
         <script src="script.js"></script>
     </head>
     <body>
-    <div class="navBar">
-        <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="career.html">Career</a></li>
-            <li><a href="research.html">Research</a></li>
-            <li><a href="fun.html" class="active" >Fun</a></li>
+        <ul class="navBar">
+            <li class="navBar"><a href="index.html">Home</a></li>
+            <li class="navBar"><a href="career.html">Career</a></li>
+            <li class="navBar"><a href="research.html">Research</a></li>
+            <li class="navBar"><a href="fun.html" class="active">Fun</a></li>
         </ul>
-    </div>
       <div id="content">
             <div id="funFact">
                 <p>Click here for a random fact about me:</p>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -6,14 +6,12 @@
     <link rel="stylesheet" href="style.css">
   </head>
   <body>
-    <div id="navBar">
-        <ul>
-            <li><a href="index.html" class="active">Home</a></li>
-            <li><a href="career.html">Career</a></li>
-            <li><a href="research.html">Research</a></li>
-            <li><a href="fun.html">Fun</a></li>
+        <ul class="navBar">
+            <li class="navBar"><a href="index.html" class="active">Home</a></li>
+            <li class="navBar"><a href="career.html">Career</a></li>
+            <li class="navBar"><a href="research.html">Research</a></li>
+            <li class="navBar"><a href="fun.html">Fun</a></li>
         </ul>
-    </div>
     <div id="content">
     	<h1>About me</h1>
         <p> My name is Dean Alvarez. I am a student at Cornell University studying

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -17,7 +17,7 @@ body{
     margin:0;
 }
 
-#navBar {
+.navBar {
     margin: 0;
     padding: 0;
 }
@@ -38,7 +38,16 @@ img.connect{
 #in {
     width: 130px;
 }
-ul {
+
+ul.experience{
+    list-style-type: none;
+    
+}
+
+
+
+
+ul.navBar {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -47,11 +56,11 @@ ul {
   background-color: #434A4E;
 }
 
-li {
+li.navBar {
   float: left;
 }
 
-li a {
+li.navBar a {
   display: block;
   font-weight: bolder;
   color: white;


### PR DESCRIPTION
I basically changed the CSS so that it was referring to a specific class for the nav bar and not just UL in general. I did this since I realized the Career and potentially research page would also have lists that I wouldn't want to be styled like the nav bar. It still looks the same as before. 

I also added the outline of what the career page will look like:
![image](https://user-images.githubusercontent.com/12815673/83274704-1eaf5a80-a19c-11ea-8f98-2ef7ca8d6d88.png)
